### PR TITLE
:bug: Fix Shop.getLocation() NoSuchMethodError + dep bumps

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,15 +20,14 @@ buildscript {
     }
 
     dependencies {
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.2.0")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.2.21")
     }
 }
 
 repositories {
     mavenCentral()
     maven("https://repo.papermc.io/repository/maven-public/")
-    maven("https://oss.sonatype.org/content/groups/public/")
-    maven("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+    maven("https://central.sonatype.com/repository/maven-snapshots/")
     maven("https://jitpack.io")
     maven("https://plugins.gradle.org/m2/")
     maven("https://repo.codemc.io/repository/maven-public/")
@@ -91,7 +90,7 @@ tasks {
     runServer {
         minecraftVersion("1.21.4")
         downloadPlugins {
-            modrinth("quickshop-hikari", "6.2.0.7")
+            modrinth("quickshop-hikari", "6.2.0.11")
             github("dmulloy2", "ProtocolLib", "5.3.0", "ProtocolLib.jar")
             url("https://ci.ender.zone/job/EssentialsX/lastSuccessfulBuild/artifact/jars/EssentialsX-2.21.0-dev+162-ea3ea20.jar")
             github("Milkbowl", "Vault", "1.7.3", "Vault.jar")

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -12,7 +12,7 @@ buildscript {
     }
 
     dependencies {
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.2.0")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.2.21")
     }
 }
 
@@ -27,7 +27,7 @@ dependencies {
     implementation(gradleApi())
     implementation(localGroovy())
     implementation(libs.kotlinx.serialization.json)
-    implementation("com.google.code.gson:gson:2.13.0")
+    implementation("com.google.code.gson:gson:2.13.2")
     compileOnly(libs.paper.api)
     implementation(libs.mock.bukkit)
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,7 +41,7 @@ koin-test-junit5 = { group = "io.insert-koin", name = "koin-test-junit5" }
 
 [plugins]
 run-paper = { id = "xyz.jpenilla.run-paper", version = "2.3.1" }
-resource-factory = { id = "xyz.jpenilla.resource-factory", version = "1.3.1" }
+resource-factory = { id = "xyz.jpenilla.resource-factory", version = "1.2.0" }
 shadow = { id = "com.github.johnrengelman.shadow", version = "8.1.1" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version = "2.2.21" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version = "2.2.21" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ coroutine = "1.10.2"
 serialization = "1.9.0"
 vault = "1.7.1"
 protocolLib = "5.3.0"
-quickShop = "6.2.0.10"
+quickShop = "6.2.0.11"
 arrow = "2.1.2"
 
 koinVersion = "4.1.0"
@@ -41,10 +41,10 @@ koin-test-junit5 = { group = "io.insert-koin", name = "koin-test-junit5" }
 
 [plugins]
 run-paper = { id = "xyz.jpenilla.run-paper", version = "2.3.1" }
-resource-factory = { id = "xyz.jpenilla.resource-factory", version = "1.2.0" }
+resource-factory = { id = "xyz.jpenilla.resource-factory", version = "1.3.1" }
 shadow = { id = "com.github.johnrengelman.shadow", version = "8.1.1" }
-kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version = "2.2.0" }
-kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version = "2.2.0" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version = "2.2.21" }
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version = "2.2.21" }
 dokka = { id = "org.jetbrains.dokka", version = "2.0.0" }
 
 


### PR DESCRIPTION
## Summary
- Fixes runtime `NoSuchMethodError: Shop.getLocation()` by bumping QuickShop-Hikari `6.2.0.10` → `6.2.0.11`. In 6.2.0.11 `Shop` extends `Locatable<Location>`, so the directly-declared `Location getLocation()` on the `Shop` interface was erased to `Object getLocation()` — plugins compiled against 6.2.0.10 reference the old signature and crash at runtime. Recompiling against 6.2.0.11 resolves it (no source change needed).
- Applies pending dependabot bumps: Kotlin `2.2.0` → `2.2.21` (#121/#122/#123), `resource-factory` `1.2.0` → `1.3.1` (#116), `gson` `2.13.0` → `2.13.2` (#117).
- Removes sunset Sonatype OSSRH repos (`oss.sonatype.org`, `s01.oss.sonatype.org`) and replaces with `central.sonatype.com/repository/maven-snapshots/`.

## Test plan
- [x] `./gradlew --refresh-dependencies compileKotlin` succeeds
- [ ] Deploy on server with QuickShop-Hikari 6.2.0.11 and run `/asf search <item>` to confirm the crash is gone