### PR TITLE
:bug: Implement fuzzy search and drop deprecated ShopType

### DIFF
--- a/src/main/kotlin/dev/nikomaru/advancedshopfinder/commands/EnchantFindCommand.kt
+++ b/src/main/kotlin/dev/nikomaru/advancedshopfinder/commands/EnchantFindCommand.kt
@@ -1,7 +1,6 @@
 package dev.nikomaru.advancedshopfinder.commands
 
 import com.ghostchu.quickshop.api.QuickShopAPI
-import com.ghostchu.quickshop.api.shop.ShopType
 import dev.nikomaru.advancedshopfinder.utils.data.FindOption
 import dev.nikomaru.advancedshopfinder.utils.data.PlayerFindOptionUtils.getPlayerFindOption
 import net.kyori.adventure.text.Component
@@ -39,14 +38,14 @@ object EnchantFindCommand: KoinComponent {
         var sum = 0
 
         val (newSellMessage, newSellSum) = ShopSearchCommand.processShops(
-            shop, sender, message, sum, options, ShopType.SELLING
+            shop, sender, message, sum, options, buying = false
         )
         message = newSellMessage
         sum = newSellSum
 
 
         val (newBuyMessage, newBuySum) = ShopSearchCommand.processShops(
-            shop, sender, message, sum, options, ShopType.BUYING
+            shop, sender, message, sum, options, buying = true
         )
         message = newBuyMessage
         sum = newBuySum

--- a/src/main/kotlin/dev/nikomaru/advancedshopfinder/commands/FuzzySearchCommand.kt
+++ b/src/main/kotlin/dev/nikomaru/advancedshopfinder/commands/FuzzySearchCommand.kt
@@ -1,27 +1,67 @@
 package dev.nikomaru.advancedshopfinder.commands
 
-import dev.nikomaru.advancedshopfinder.search.FuzzySearcher
-import dev.nikomaru.advancedshopfinder.search.Searcher
+import com.ghostchu.quickshop.api.QuickShopAPI
+import dev.nikomaru.advancedshopfinder.files.server.ConfigData
+import dev.nikomaru.advancedshopfinder.utils.data.FindOption
+import dev.nikomaru.advancedshopfinder.utils.data.PlayerFindOptionUtils.getPlayerFindOption
+import dev.nikomaru.advancedshopfinder.utils.translate.TranslateManager
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer
 import org.bukkit.command.CommandSender
 import org.bukkit.entity.Player
 import org.incendo.cloud.annotations.Argument
 import org.incendo.cloud.annotations.Command
 import org.koin.core.component.KoinComponent
+import org.koin.core.component.get
+import org.koin.core.component.inject
 import java.util.Locale
 
 @Command("advancedshopfinder|asf|shopfinder|sf")
-object FuzzySearchCommand: KoinComponent {
-    @Command("fuzzy-search <name>")
-    fun fuzzySearch(sender: CommandSender, @Argument("name") name: String) {
-        val locale = if (sender is Player) sender.locale() else Locale.getDefault()
-        val searcher: Searcher<Pair<String, Locale>> = FuzzySearcher()
-        searcher
-            .search(Pair(name, locale))
-            .mapLeft {
-                sender.sendMessage(it.message)
-            }.map {
-                //it.sortWith(playerFindOption.sortComparator).display(sender)
+object FuzzySearchCommand : KoinComponent {
+    private val translateManager: TranslateManager by inject()
+    private val quickShop: QuickShopAPI by inject()
 
-            }
+    @Command("fuzzy-search <name>")
+    suspend fun fuzzySearch(sender: CommandSender, @Argument("name") name: String) {
+        val locale = if (sender is Player) sender.locale() else Locale.getDefault()
+        val needle = name.lowercase()
+        val keySet = translateManager.getTranslateMap(locale)
+            .filter { (k, v) -> v.lowercase().contains(needle) || k.key.lowercase().contains(needle) }
+            .keys
+            .map { it.key.lowercase() }
+            .toHashSet()
+
+        val plain = PlainTextComponentSerializer.plainText()
+        val options = (sender as? Player)?.getPlayerFindOption() ?: FindOption()
+        val shop = quickShop.shopManager.allShops.filter {
+            keySet.contains(it.item.type.translationKey().lowercase())
+                || plain.serialize(it.item.displayName()).lowercase().contains(needle)
+        }
+        if (shop.isEmpty()) {
+            sender.sendRichMessage("検索結果: 0件")
+            return
+        }
+        if (shop.size > get<ConfigData>().fuzzySearchLimit) {
+            sender.sendRichMessage("検索結果が多すぎます。絞り込んでください。")
+            return
+        }
+
+        var message: Component = Component.text("")
+        var sum = 0
+
+        val (newSellMessage, newSellSum) = ShopSearchCommand.processShops(
+            shop, sender, message, sum, options, buying = false
+        )
+        message = newSellMessage
+        sum = newSellSum
+
+        val (newBuyMessage, newBuySum) = ShopSearchCommand.processShops(
+            shop, sender, message, sum, options, buying = true
+        )
+        message = newBuyMessage
+        sum = newBuySum
+
+        sender.sendRichMessage("<color:green>${name} の検索結果: ${sum}件")
+        sender.sendMessage(message)
     }
 }

--- a/src/main/kotlin/dev/nikomaru/advancedshopfinder/commands/ShopSearchCommand.kt
+++ b/src/main/kotlin/dev/nikomaru/advancedshopfinder/commands/ShopSearchCommand.kt
@@ -2,7 +2,6 @@ package dev.nikomaru.advancedshopfinder.commands
 
 import com.ghostchu.quickshop.api.QuickShopAPI
 import com.ghostchu.quickshop.api.shop.Shop
-import com.ghostchu.quickshop.api.shop.ShopType
 import com.github.shynixn.mccoroutine.bukkit.launch
 import dev.nikomaru.advancedshopfinder.AdvancedShopFinder
 import dev.nikomaru.advancedshopfinder.files.server.ConfigData
@@ -55,12 +54,12 @@ object ShopSearchCommand : KoinComponent {
         var message: Component = Component.text("")
         var sum = 0
 
-        val (newSellMessage, newSellSum) = processShops(shop, sender, message, sum, options, ShopType.SELLING)
+        val (newSellMessage, newSellSum) = processShops(shop, sender, message, sum, options, buying = false)
         message = newSellMessage
         sum = newSellSum
 
 
-        val (newBuyMessage, newBuySum) = processShops(shop, sender, message, sum, options, ShopType.BUYING)
+        val (newBuyMessage, newBuySum) = processShops(shop, sender, message, sum, options, buying = true)
         message = newBuyMessage
         sum = newBuySum
 
@@ -68,16 +67,16 @@ object ShopSearchCommand : KoinComponent {
         sender.sendMessage(message)
     }
 
-    suspend fun processShops(shop: List<Shop>, sender: CommandSender, message: Component, sum: Int, options: FindOption, shopType: ShopType): Pair<Component, Int> {
+    suspend fun processShops(shop: List<Shop>, sender: CommandSender, message: Component, sum: Int, options: FindOption, buying: Boolean): Pair<Component, Int> {
         var filteredShops = shop.filter {
-            it.shopType==shopType && (withContext(Dispatchers.minecraft) {
-                if (shopType==ShopType.SELLING) it.remainingStock else it.remainingSpace
+            it.isBuying == buying && (withContext(Dispatchers.minecraft) {
+                if (buying) it.remainingSpace else it.remainingStock
             } > 0 || it.isUnlimited)
         }
-        val sortType = if (shopType==ShopType.SELLING) options.sortOption.sellSortType else options.sortOption.buySortType
+        val sortType = if (buying) options.sortOption.buySortType else options.sortOption.sellSortType
         if (sender !is Player) {
-            filteredShops = if (shopType==ShopType.SELLING) filteredShops.sortedByDescending { it.price }
-            else filteredShops.sortedBy { it.price }
+            filteredShops = if (buying) filteredShops.sortedBy { it.price }
+            else filteredShops.sortedByDescending { it.price }
         } else {
             filteredShops = when (sortType) {
                 SortType.ASC_PRICE_PER_STACK -> filteredShops.sortedBy { it.price }

--- a/src/main/kotlin/dev/nikomaru/advancedshopfinder/search/FuzzySearcher.kt
+++ b/src/main/kotlin/dev/nikomaru/advancedshopfinder/search/FuzzySearcher.kt
@@ -1,6 +1,7 @@
 package dev.nikomaru.advancedshopfinder.search
 
 import arrow.core.Either
+import arrow.core.left
 import arrow.core.right
 import com.ghostchu.quickshop.api.QuickShopAPI
 import dev.nikomaru.advancedshopfinder.search.error.ShopSearchError
@@ -8,20 +9,24 @@ import dev.nikomaru.advancedshopfinder.utils.translate.TranslateManager
 import org.bukkit.inventory.ItemStack
 import org.koin.core.component.inject
 import java.util.Locale
-import kotlin.collections.component1
-import kotlin.collections.component2
 
 class FuzzySearcher : Searcher<Pair<String, Locale>> {
     val quickShopAPI: QuickShopAPI by inject()
     val translateManager: TranslateManager by inject()
 
     override fun search(query: Pair<String, Locale>): Either<ShopSearchError, ArrayList<ItemStack>> {
-        translateManager.getTranslateMap(query.second).filter { (k, v) ->
-            v.contains(query.first) || k.key.contains(query.first)
-        }.map {
-            it.key
-        }
+        val needle = query.first.lowercase()
+        val matchedKeys = translateManager.getTranslateMap(query.second)
+            .filter { (k, v) ->
+                v.lowercase().contains(needle) || k.key.lowercase().contains(needle)
+            }
+            .keys
 
-        TODO()
+        if (matchedKeys.isEmpty()) return ShopSearchError.NO_SHOP_FOUND.left()
+
+        val shops = quickShopAPI.shopManager.allShops.filter { it.item.type.key in matchedKeys }
+
+        if (shops.isEmpty()) return ShopSearchError.NO_SHOP_FOUND.left()
+        return shops.map { it.item }.toCollection(ArrayList()).right()
     }
 }


### PR DESCRIPTION
## Summary
- `FuzzySearcher` / `FuzzySearchCommand` の `TODO()` が残っていて `/asf fuzzy-search` 実行時に `NotImplementedError` で落ちていたので、翻訳マップベースのあいまい検索を復元 (`fuzzySearchLimit`、`processShops` での売買別表示込み)
- QuickShop 6.2.0.11 で `@Deprecated(forRemoval)` になった `com.ghostchu.quickshop.api.shop.ShopType` enum への依存を除去。`processShops` のシグネチャを `shopType: ShopType` → `buying: Boolean` に変え、`Shop.isBuying` (非 deprecated) で判定するよう統一

## Test plan
- [x] `./gradlew compileKotlin` がエラー/deprecation 警告なしで通ること
- [ ] `/asf fuzzy-search <name>` がスタックトレースを出さずに検索結果を返すこと (日本語/英語 locale 双方)
- [ ] `/asf search <item>` の売買別表示が従来通りに動くこと (`processShops` のリファクタ回帰チェック)
- [ ] `/asf search-book <enchantment>` も同様に動くこと